### PR TITLE
ARM32 fixes

### DIFF
--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -96,6 +96,9 @@ void RtlCopyMemory(
 
 void* RtlAllocateMemory(BOOL InZeroMemory, ULONG InSize)
 {
+	DETOUR_TRACE(("RtlAllocateMemory InHandle=%p, InZeroMemory=%d, InSize=%d \n",
+        hCoreHookHeap, InZeroMemory, InSize) );
+
     void*       Result = 
 #ifdef _DEBUG
 		HeapAlloc(hCoreHookHeap, 0, InSize);
@@ -324,6 +327,9 @@ Parameters:
 		DWORD dwOld2;
 		VirtualProtect(InAcl, sizeof(HOOK_ACL), dwOld, &dwOld2);
 	}
+    else {
+        return -3;
+    }
 
     return 0;
 }

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -96,9 +96,6 @@ void RtlCopyMemory(
 
 void* RtlAllocateMemory(BOOL InZeroMemory, ULONG InSize)
 {
-	DETOUR_TRACE(("RtlAllocateMemory InHandle=%p, InZeroMemory=%d, InSize=%d \n",
-        hCoreHookHeap, InZeroMemory, InSize) );
-
     void*       Result = 
 #ifdef _DEBUG
 		HeapAlloc(hCoreHookHeap, 0, InSize);

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -572,7 +572,7 @@ BOOL WINAPI DetourUpdateProcessWithDll(_In_ HANDLE hProcess,
         }
     }
 
-    DETOUR_TRACE(("    32BitExe=%d 32BitProcess\n", bHas32BitExe, bIs32BitProcess));
+    DETOUR_TRACE(("    32BitExe=%d 32BitProcess=%d\n", bHas32BitExe, bIs32BitProcess));
 
     return DetourUpdateProcessWithDllEx(hProcess,
                                         hModule,
@@ -606,7 +606,7 @@ BOOL WINAPI DetourUpdateProcessWithDllEx(_In_ HANDLE hProcess,
         bIs32BitExe = TRUE;
     }
 
-    DETOUR_TRACE(("    32BitExe=%d 32BitProcess\n", bIs32BitExe, bIs32BitProcess));
+    DETOUR_TRACE(("    32BitExe=%d 32BitProcess=%d\n", bIs32BitExe, bIs32BitProcess));
 
     if (hModule == NULL) {
         SetLastError(ERROR_INVALID_OPERATION);

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -102,9 +102,9 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
     }
 
     DETOUR_TRACE(("     Imports: %p..%p\n",
-                  (DWORD_PTR)pbModule + inh.IMPORT_DIRECTORY.VirtualAddress,
-                  (DWORD_PTR)pbModule + inh.IMPORT_DIRECTORY.VirtualAddress +
-                  inh.IMPORT_DIRECTORY.Size));
+                  (PVOID)((DWORD_PTR)pbModule + inh.IMPORT_DIRECTORY.VirtualAddress),
+                  (PVOID)((DWORD_PTR)pbModule + inh.IMPORT_DIRECTORY.VirtualAddress +
+                  inh.IMPORT_DIRECTORY.Size)));
 
     DWORD nOldDlls = inh.IMPORT_DIRECTORY.Size / sizeof(IMAGE_IMPORT_DESCRIPTOR);
     DWORD obRem = sizeof(IMAGE_IMPORT_DESCRIPTOR) * nDlls;


### PR DESCRIPTION
- Fix the ARM32 dotnet trampoline to save the correct registers
- ARM32 branch calls will have the proper addresses since we are DETOURS_PBYTE_TO_PFUNC to get the  address for detour and original functions when creating out trampoline